### PR TITLE
Fix updating kubelet version on slaves

### DIFF
--- a/kubelet/1.0.0/actions/run.yaml
+++ b/kubelet/1.0.0/actions/run.yaml
@@ -3,8 +3,9 @@
   tasks:
     - get_url:
         url: http://storage.googleapis.com/kubernetes-release/release/{{k8s_version}}/bin/linux/amd64/kubelet
-        dest: /usr/bin/kubelet
-    - shell: chmod +x /usr/bin/kubelet
+        dest: /usr/bin/kubelet{{k8s_version}}
+    - shell: chmod +x /usr/bin/kubelet{{k8s_version}}
+    - file: force=yes src=/usr/bin/kubelet{{k8s_version}} path=/usr/bin/kubelet state=link
     - file: name=/etc/kubernetes/manifests state=directory
     - template:
         src: {{templates_dir}}/kubelet.service

--- a/kubelet/1.0.0/actions/update.yaml
+++ b/kubelet/1.0.0/actions/update.yaml
@@ -3,8 +3,9 @@
   tasks:
     - get_url:
         url: http://storage.googleapis.com/kubernetes-release/release/{{k8s_version}}/bin/linux/amd64/kubelet
-        dest: /usr/bin/kubelet
-    - shell: chmod +x /usr/bin/kubelet
+        dest: /usr/bin/kubelet{{k8s_version}}
+    - shell: chmod +x /usr/bin/kubelet{{k8s_version}}
+    - file: force=yes src=/usr/bin/kubelet{{k8s_version}} path=/usr/bin/kubelet state=link
     - file: name=/etc/kubernetes/manifests state=directory
     - template:
         src: {{templates_dir}}/kubelet.service

--- a/kubelet_master/1.0.0/actions/run.yaml
+++ b/kubelet_master/1.0.0/actions/run.yaml
@@ -9,8 +9,8 @@
         dest: /usr/bin/kubelet{{k8s_version}}
     - file: name=/usr/bin/kubectl{{k8s_version}} mode=0777
     - file: name=/usr/bin/kubelet{{k8s_version}} mode=0777
-    - file: force=yes src=/usr/bin/kubectl{{k8s_version}} path=/usr/bin/kubectl state=link
-    - file: force=yes src=/usr/bin/kubelet{{k8s_version}} path=/usr/bin/kubelet state=link
+    - file: src=/usr/bin/kubectl{{k8s_version}} path=/usr/bin/kubectl state=link
+    - file: src=/usr/bin/kubelet{{k8s_version}} path=/usr/bin/kubelet state=link
     - file: name=/etc/kubernetes/manifests state=directory
     - template:
         src: {{templates_dir}}/kubelet.service

--- a/kubelet_master/1.0.0/actions/run.yaml
+++ b/kubelet_master/1.0.0/actions/run.yaml
@@ -3,12 +3,14 @@
   tasks:
     - get_url:
         url: http://storage.googleapis.com/kubernetes-release/release/{{k8s_version}}/bin/linux/amd64/kubectl
-        dest: /usr/bin/kubectl
+        dest: /usr/bin/kubectl{{k8s_version}}
     - get_url:
         url: http://storage.googleapis.com/kubernetes-release/release/{{k8s_version}}/bin/linux/amd64/kubelet
-        dest: /usr/bin/kubelet
-    - shell: chmod +x /usr/bin/kubectl
-    - shell: chmod +x /usr/bin/kubelet
+        dest: /usr/bin/kubelet{{k8s_version}}
+    - file: name=/usr/bin/kubectl{{k8s_version}} mode=0777
+    - file: name=/usr/bin/kubelet{{k8s_version}} mode=0777
+    - file: force=yes src=/usr/bin/kubectl{{k8s_version}} path=/usr/bin/kubectl state=link
+    - file: force=yes src=/usr/bin/kubelet{{k8s_version}} path=/usr/bin/kubelet state=link
     - file: name=/etc/kubernetes/manifests state=directory
     - template:
         src: {{templates_dir}}/kubelet.service

--- a/kubelet_master/1.0.0/actions/update.yaml
+++ b/kubelet_master/1.0.0/actions/update.yaml
@@ -9,8 +9,8 @@
         dest: /usr/bin/kubelet{{k8s_version}}
     - file: name=/usr/bin/kubectl{{k8s_version}} mode=0777
     - file: name=/usr/bin/kubelet{{k8s_version}} mode=0777
-    - file: force=yes src=/usr/bin/kubectl{{k8s_version}} path=/usr/bin/kubectl state=link
-    - file: force=yes src=/usr/bin/kubelet{{k8s_version}} path=/usr/bin/kubelet state=link
+    - file: src=/usr/bin/kubectl{{k8s_version}} path=/usr/bin/kubectl state=link
+    - file: src=/usr/bin/kubelet{{k8s_version}} path=/usr/bin/kubelet state=link
     - file: name=/etc/kubernetes/manifests state=directory
     - template:
         src: {{templates_dir}}/kubelet.service

--- a/kubelet_master/1.0.0/actions/update.yaml
+++ b/kubelet_master/1.0.0/actions/update.yaml
@@ -3,12 +3,14 @@
   tasks:
     - get_url:
         url: http://storage.googleapis.com/kubernetes-release/release/{{k8s_version}}/bin/linux/amd64/kubectl
-        dest: /usr/bin/kubectl
+        dest: /usr/bin/kubectl{{k8s_version}}
     - get_url:
         url: http://storage.googleapis.com/kubernetes-release/release/{{k8s_version}}/bin/linux/amd64/kubelet
-        dest: /usr/bin/kubelet
-    - shell: chmod +x /usr/bin/kubectl
-    - shell: chmod +x /usr/bin/kubelet
+        dest: /usr/bin/kubelet{{k8s_version}}
+    - file: name=/usr/bin/kubectl{{k8s_version}} mode=0777
+    - file: name=/usr/bin/kubelet{{k8s_version}} mode=0777
+    - file: force=yes src=/usr/bin/kubectl{{k8s_version}} path=/usr/bin/kubectl state=link
+    - file: force=yes src=/usr/bin/kubelet{{k8s_version}} path=/usr/bin/kubelet state=link
     - file: name=/etc/kubernetes/manifests state=directory
     - template:
         src: {{templates_dir}}/kubelet.service

--- a/setup_k8s.py
+++ b/setup_k8s.py
@@ -32,7 +32,7 @@ def get_free_slave_ip(available_ips):
         raise ValueError('No free IP addresses available. '
                          'Did you edit config.yaml?')
 
-    return list(sorted(free_ips))[0]
+    return sorted(free_ips)[0]
 
 
 def setup_master(config, user_config):


### PR DESCRIPTION
Also fixed IP address allocation.
get_url didn't download the file if it was already there.
Symlinks are used to link to current version of binary.
