### PR TITLE
Possibility to set all values of global_config in yaml file

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -4,9 +4,9 @@ kube_master:
   password: vagrant
   ssh_key: null
   ip: 10.0.0.3
-dns:
-  ip: 10.254.0.10
-  domain: cluster.local
+global_config:
+  cluster_dns: 10.254.0.10
+  cluster_domain: cluster.local
 kube_slaves:
   default:
     username: vagrant

--- a/setup_k8s.py
+++ b/setup_k8s.py
@@ -11,16 +11,13 @@ from solar.core.resource import resource as rs
 from solar.events.api import add_event
 from solar.events.controls import Dep
 
-
 DEFAULT_MASTER_NODE_RESOURCE_NAME = 'kube-node-master'
 MASTER_NODE_RESOURCE_NAME = None
 
 
-def create_config(dns_config):
+def create_config(global_config):
     return cr.create('kube-config', 'k8s/global_config',
-                     {'cluster_dns': dns_config['ip'],
-                      'cluster_domain': dns_config['domain']}
-                     )[0]
+                     global_config)[0]
 
 
 def get_slave_nodes():
@@ -233,7 +230,7 @@ def get_master_and_slave_nodes():
 def deploy_k8s(args, user_config):
     master_node, slave_nodes = get_master_and_slave_nodes()
 
-    config = create_config(user_config['dns'])
+    config = create_config(user_config['global_config'])
 
     setup_master(config, user_config['kube_master'], master_node)
     setup_nodes(config, user_config['kube_slaves']['slaves'],


### PR DESCRIPTION
User can now set all `global_config` resource values in `global_config` section of config file.

For advanced setup (ie set version on single node) manual intervention is still needed.
